### PR TITLE
Adjust INCAR so that benchmark run longer for better statistics

### DIFF
--- a/compute/VASP/B.hR105/INCAR
+++ b/compute/VASP/B.hR105/INCAR
@@ -16,9 +16,9 @@ SYSTEM = B.hR105 with PBE0/HSE06
 
  Electronic Relaxation
    ALGO   = Normal # Use Conjugate Gradient to allow HF-calcs
-   EDIFF  = 1E-06  # stopping-criterion for ELM
-   NELM     = 6      # maximum number of electronic SC steps
-
+   EDIFF  = 1E-10  # stopping-criterion for ELM
+   NELM   = 30     # maximum number of electronic SC steps
+   NELMDL = 5
  Ionic Relaxation
    NSW    = 1    # maximum number of ionic steps 
    ISIF   = 2    # calculate/relax/change everything

--- a/compute/VASP/Pt_111/INCAR
+++ b/compute/VASP/Pt_111/INCAR
@@ -10,10 +10,10 @@ System = Pt111-Surface
    PREC     = Normal # Normal defaults
 
  Electronic Relaxation
-   ALGO   = Very Fast # Use Congugate Gradient to allow HF-calcs
-   NELM   = 25     # maximum number of electronic SC steps
+   ALGO   = Fast # Use Congugate Gradient to allow HF-calcs
+   NELM   = 30     # maximum number of electronic SC steps
    NELMDL = 5 
-   EDIFF  = 1E-07  # stopping-criterion for ELM
+   EDIFF  = 1E-10  # stopping-criterion for ELM
 
  Ionic Relaxation
    NSW    = 0    # maximum number of ionic steps

--- a/compute/VASP/README.md
+++ b/compute/VASP/README.md
@@ -1,10 +1,10 @@
 # VASP Benchmark
-**Version**: VASP.5.4.4.18APR17  
+**Version**: VASP.5.4.4.18APR17 **or** VASP 6.1.1.19JUN20 
 **Website**: https://www.vasp.at/
 
 ## Benchmark rules
 
-* Only VASP version **5.4.4 with 18ARR17 patch** is allowed
+* Only VASP versions **5.4.4 with 18ARR17 patch** or **6.1.1 19Jun20** is allowed
 * No code modification is allowed
 * Calculation must be performed with double-precision accuracy
 * Only `vasp_std` and `vasp_gam` are allowed (when applicable)
@@ -36,8 +36,8 @@ Each of the system represent various workload/algorithm that are common among VA
 | POTCAR        | B        | Pt        | Ti_sv, O | Zr_sv, O |
 | ENCUT (eV)    | 319      | 400       | 450      | 450      |
 | PREC          | Normal   | Normal    | Accurate | Accurate |
-| ALGO          | Normal   | Very Fast | Fast     | Normal   |
-| NELM (NELMDL) | 6 (5)    | 25 (5)    | 10 (3)   | 10 (3)   |
+| ALGO          | Normal   | Fast      | Fast     | Normal   |
+| NELM (NELMDL) | 30 (5)   | 30 (5)    | 30 (5)   | 50 (5)   |
 | KPOINTS       | 2 2 2    | 2 2 1     | 1 1 1    | 3 3 1    |
 
 ## Running

--- a/compute/VASP/TiO2/INCAR
+++ b/compute/VASP/TiO2/INCAR
@@ -1,4 +1,4 @@
-SYSTEM = ZrO2_Surface
+SYSTEM = TiO2_Surface
 
 ISTART = 0
 LWAVE  = F
@@ -7,9 +7,9 @@ LCHARG = F
 #Electronic Relaxation
 PREC = Accurate
 ENCUT = 450
-NELM   = 10
-NELMDL = 3
-EDIFF  = 1E-07
+NELM   = 30
+NELMDL = 5
+EDIFF  = 1E-10
 
 #Ionic Relaxation
 NSW    = 0

--- a/compute/VASP/ZrO2/INCAR
+++ b/compute/VASP/ZrO2/INCAR
@@ -1,36 +1,33 @@
 SYSTEM = ZrO2_Surface
 
- Global Settings
-   ISMEAR   = 0      # gaussian smearing
-   SIGMA    = 0.1    # broadening
-   LREAL    = A      # evaluate projection operators in real space 
-   ENCUT    = 450    # Energy cutoff
-   ISPIN    = 2      # Spin polarized calculation
-   ISYM     = 0
+ISTART = 0
+LWAVE  = F
+LCHARG = F
 
- Discretization
-   PREC     = Accurate # Accurate defaults
-   NBANDS   = 680  # For consistency
+#Electronic Relaxation
+PREC = Accurate
+ENCUT = 450
+NELM   = 50
+NELMDL = 5
+EDIFF  = 1E-10
+NBANDS = 680
 
+#Ionic Relaxation
+NSW    = 0
+IBRION = 2
+ISIF   = 2
+ISYM   = 0
 
- Electronic Relaxation
-   ALGO   = Normal # Use Conjugate Gradient to allow HF-calcs
-   EDIFF  = 1E-07  # stopping-criterion for ELM
-   NELM   = 10     # maximum number of electronic SC steps
-   NELMDL = 3
+#DOS related values:
+ISMEAR =  0
+SIGMA  =  0.1
 
- Ionic Relaxation
-   NSW    = 0    # maximum number of ionic steps 
-   ISIF   = 2    # calculate/relax/change everything
-   IBRION = 2    # ion update algorithm (2 = CG)
-   
+#Electronic Relaxation
+ALGO   = Normal
+LREAL  = A
+ISPIN  = 2
 
- Input/Output
-   ISTART = 0 # Start from scratch
-   LWAVE  = F # Don't store the WAVECAR
-   LCHARG = F # Don't store the CHGCAR
+#Tunable parameters
+NCORE = 40
+NSIM = 4
 
- Tunable parameters
-   NCORE  = 40
-   NSIM   = 4
-   


### PR DESCRIPTION
- Adjust INCAR Adjust INCAR so that benchmark run longer for better statistics
- Allow version 6.1.1 for benchmark